### PR TITLE
Package additons, Refactoring & Docs Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,115 @@
 # roosevelt-logger
 
-Intuitive, attractive logger for Node.js applications based on Winston.
+Intuitive, attractive logger for Node.js applications based on [Winston](https://github.com/winstonjs/winston). This module was built and is maintained by the [Roosevelt web framework team](https://github.com/rooseveltframework/roosevelt), but it can be used independently of Roosevelt as well.
 
 ## Install
 
-You can install `roosevelt-logger` from NPM:
-
-```
-npm install roosevelt-logger
-```
+First declare `roosevelt-logger` as a dependency in your app.
 
 ## Usage
 
-To use the `roosevelt-logger` simply require the package into your application:
+Require the package into your application and call its constructor:
 
 ```js
 const logger = require('roosevelt-logger')()
+
+logger.log('some info')
+logger.warn('a warning')
+logger.error('an error')
+logger.verbose('noisy log only displayed when verbose is enabled')
 ```
 
-Optionally you can pass the logger a set of configurations. There are default log types that can be enabled and disabled. Additionally custom log types can also be added.
+This would output the following:
 
-* Default log types: *[Object]*
-  ```json
-  {
-    "info": true,
-    "warnings": true,
-    "verbose": false
-  }
-  ```
-* Custom log types: *[Object]*
-  ```json
-  {
-    "debug": {
-      "enable": true,
-      "type": "error"
+```
+some info
+⚠️  a warning
+❌  an error
+```
+
+## Configure logger
+
+Optionally you can pass the logger a set of configs:
+
+- `info` *[Boolean]*: Enable regular logs.
+
+  - Default: `true`.
+
+- `warnings` *[Boolean]*: Enable logging of warnings.
+
+  - Default: `true`.
+
+- `verbose` *[Boolean]*: Enable verbose (noisy) logging.
+
+  - Default: `false`.
+
+- `disable` *[Array of Strings]*: Disable logging in certain environments. Each entry can be either an environment variable or a set NODE_ENV string.
+
+  - Default: `[]`.
+  - Example usage:
+    -`['LOADED_MOCHA_OPTS']` (disables logger when being run by [Mocha](https://mochajs.org/).)
+    -`['production']` (disables logger when NODE_ENV is set to 'production'.)
+
+- Custom log type *[Object]*: You can also define your own log types and specify what native log type it maps to.
+
+  - API:
+
+    - `enable` *[Boolean]*: Enable this custom log.
+      - Default:  `true`.
+    - `type` *[String]*: What type of native log this custom log maps to.
+      - Default: `info`
+      - Allowed values: `info`, `warn`, or `error`.
+    - `prefix`: *[String]*: The string that prefixes any log entry. If set to a falsy item (null, an empty string, etc), the prefix will be disabled for the following log type.
+      - default: If not set, default to the prefix of the type (i.e.: if the type is `warn`, the prefix will default to `⚠️`)
+
+  - Simple custom type example for a new log type called `dbError`:
+
+    ```json
+    {
+      "dbError": {}
     }
-  }
-  ```
-  * `enable`: Enables or disables the custom log.
-    * Default: *[Boolean]* `true`.
-  * `type`: Specifies what kind of log your custom log is:
-    * Allowed values: *[String]* `info`, `warn`, or `error`.
-* Disable logging in certain environments:
-  * Example: `'disable': ['LOADED_MOCHA_OPTS']`
+    ```
 
-Example usage of a custom configuration with the `roosevelt-logger`:
+  - The above example would create a custom log type `dbError`. Since no params are supplied to it, it defaults to being enabled and defaults to log type `info` and no prefix.
+
+  - Complex custom type example:
+
+    ```json
+    {
+      "dbError": {
+        "enable": false,
+        "type": "error",
+        "prefix": "🗄"
+      }
+    }
+    ```
+
+## Usage with custom configs
+
+Require the package into your application and call its constructor:
 
 ```js
 const logger = require('roosevelt-logger')({
-  "info": true,
-  "warnings": true,
-  "verbose": false,
-  "debug": {
-    "enable": true,
-    "type": "error"
-  },
-  "disable": ['production']
+    verbose: true,
+    dbError: {
+        type: "error",
+    }
+    disable: ['LOADED_MOCHA_OPTS']
 })
+
+logger.log('some info')
+logger.warn('a warning')
+logger.error('an error')
+logger.verbose('noisy log only displayed when verbose is enabled')
+logger.dbError('custom log for database errors')
 ```
 
-## Unit Tests
+[TODO: show output of above example.]
 
-To run the unit tests use the command:
+## Properties of roosevelt-logger module
 
-```
-npm run test
-```
+In addition to the constructor, roosevelt-logger exposes the following properties:
 
-To run the unit tests with a coverage report use the command:
-
-```
-npm run coverage
-```
+* `winston`: *[Function]*: The instance of [Winston](https://www.npmjs.com/package/winston) that roosevelt-logger uses internally.
+* `winstonLogger`: The specific logger instance of [Winston](https://www.npmjs.com/package/winston) in roosevelt-logger.
+* `transports`: The default transports enabled by roosevelt-logger.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ some info
 
 ## Configure logger
 
-Optionally you can pass the logger a set of configs:
+Optionally you can pass the logger a set of configs. Each config type that maps to a default log type can be set to either a boolean to enable / disable the log or an object :
 
 - `info` *[Boolean]*: Enable regular logs.
 
@@ -43,12 +43,14 @@ Optionally you can pass the logger a set of configs:
 
   - Default: `false`.
 
-- `disable` *[Array of Strings]*: Disable logging in certain environments. Each entry can be either an environment variable or a set NODE_ENV string.
+- `disable` *[Array of Strings]*: Disable logging in certain environments. Each entry can be either an environment variable or a set NODE_ENV mode.
 
   - Default: `[]`.
   - Example usage:
     -`['LOADED_MOCHA_OPTS']` (disables logger when being run by [Mocha](https://mochajs.org/).)
     -`['production']` (disables logger when NODE_ENV is set to 'production'.)
+
+- `enablePrefix` *[Boolean]*: Enable prefixes which can contain emojis to be prepended to logs. This can also be toggled with the `ROOSEVELT_LOGGER_ENABLE_PREFIX` environment variable.
 
 - Custom log type *[Object]*: You can also define your own log types and specify what native log type it maps to.
 
@@ -61,6 +63,8 @@ Optionally you can pass the logger a set of configs:
       - Allowed values: `info`, `warn`, or `error`.
     - `prefix`: *[String]*: The string that prefixes any log entry. If set to a falsy item (null, an empty string, etc), the prefix will be disabled for the following log type.
       - default: If not set, default to the prefix of the type (i.e.: if the type is `warn`, the prefix will default to `⚠️`)
+    - `color`: *[String]*: The color that the text will be set to using [Colors](https://www.npmjs.com/package/colors).
+      - default: If not set, it will default to the color of the type for `warn` and `error`, and no color for `info`.
 
   - Simple custom type example for a new log type called `dbError`:
 
@@ -70,7 +74,7 @@ Optionally you can pass the logger a set of configs:
     }
     ```
 
-  - The above example would create a custom log type `dbError`. Since no params are supplied to it, it defaults to being enabled and defaults to log type `info` and no prefix.
+  - The above example would create a custom log type `dbError`. Since no params are supplied to it, it defaults to being enabled and defaults to log type `info` and no prefix or color.
 
   - Complex custom type example:
 
@@ -79,7 +83,8 @@ Optionally you can pass the logger a set of configs:
       "dbError": {
         "enable": false,
         "type": "error",
-        "prefix": "🗄"
+        "prefix": "🗄",
+        "color": "cyan"
       }
     }
     ```
@@ -92,7 +97,8 @@ Require the package into your application and call its constructor:
 const logger = require('roosevelt-logger')({
     verbose: true,
     dbError: {
-        type: "error",
+        type: 'error',
+        prefix: '🗄'
     }
     disable: ['LOADED_MOCHA_OPTS']
 })
@@ -104,7 +110,15 @@ logger.verbose('noisy log only displayed when verbose is enabled')
 logger.dbError('custom log for database errors')
 ```
 
-[TODO: show output of above example.]
+Output:
+
+```
+some info
+⚠️ a warning
+❌ an error
+noisy log only displayed when verbose is enabled
+🗄 custom log for database errors
+```
 
 ## Properties of roosevelt-logger module
 

--- a/defaults.json
+++ b/defaults.json
@@ -2,23 +2,27 @@
   "info": {
     "type": "info",
     "enable": true,
-    "prefix": false
+    "prefix": false,
+    "color": false
   },
   "warn": {
     "type": "warn",
     "enable": true,
-    "prefix": "⚠️"
+    "prefix": "⚠️ ",
+    "color": "yellow"
   },
   "error": {
     "type": "error",
     "enable": true,
-    "prefix": "❌"
+    "prefix": "❌",
+    "color": "red"
   },
   "verbose": {
     "type": "info",
     "enable": false,
-    "prefix": false
+    "prefix": false,
+    "color": false
   },
-  "emoji": true,
+  "enablePrefix": true,
   "disable": []
 }

--- a/defaults.json
+++ b/defaults.json
@@ -1,6 +1,24 @@
 {
-  "info": true,
-  "warnings": true,
-  "verbose": false,
-  "emoji": true
+  "info": {
+    "type": "info",
+    "enable": true,
+    "prefix": false
+  },
+  "warn": {
+    "type": "warn",
+    "enable": true,
+    "prefix": "⚠️"
+  },
+  "error": {
+    "type": "error",
+    "enable": true,
+    "prefix": "❌"
+  },
+  "verbose": {
+    "type": "info",
+    "enable": false,
+    "prefix": false
+  },
+  "emoji": true,
+  "disable": []
 }

--- a/logger.js
+++ b/logger.js
@@ -80,8 +80,56 @@ function removeEmojis (str) {
   return words.join('')
 }
 
+function setParams (params) {
+  let newParams = {}
+  // loop params and assign values
+  for (let key in params) {
+    if (defaults[key]) {
+      if (key === 'emoji') {
+        newParams[key] = typeof params[key] === 'boolean' ? params[key] : defaults[key]
+      } else if (key === 'disable') {
+        newParams[key] = Array.isArray(params[key]) ? params[key] : defaults[key]
+      } else if (typeof params[key] === 'object') {
+        newParams[key] = {
+          type: (params[key]['type'] && typeof params[key]['type'] === 'string') ? params[key]['type'] : defaults[key]['type'],
+          enable: (params[key]['enable'] && typeof params[key]['enable'] === 'boolean') ? params[key]['enable'] : defaults[key]['enable'],
+          prefix: (params[key]['prefix'] && (typeof params[key]['prefix'] === 'string' || typeof params[key]['prefix'] === 'boolean')) ? params[key]['prefix'] : defaults[key]['prefix']
+        }
+      } else if (typeof params[key] === 'boolean') {
+        newParams[key] = {
+          type: defaults[key]['type'],
+          enable: params[key],
+          prefix: defaults[key]['prefix']
+        }
+      }
+    } else {
+      if (typeof params[key] === 'object') {
+        newParams[key] = {
+          type: (params[key]['type'] && typeof params[key]['type'] === 'string') ? params[key]['type'] : 'info',
+          enable: (params[key]['enable'] && typeof params[key]['enable'] === 'boolean') ? params[key]['enable'] : true,
+          prefix: (params[key]['prefix'] && (typeof params[key]['prefix'] === 'string' || typeof params[key]['prefix'] === 'boolean')) ? params[key]['prefix'] : false
+        }
+      } else if (typeof params[key] === 'boolean') {
+        newParams[key] = {
+          type: 'info',
+          enable: params[key],
+          prefix: false
+        }
+      }
+    }
+  }
+  // loop defaults to make sure the newParams contains all default log types
+  for (let key in defaults) {
+    if (!newParams[key]) {
+      newParams[key] = defaults[key]
+    }
+  }
+  return newParams
+}
+
 class Logger {
   constructor (params) {
+    params = setParams(params)
     // check to see if parameters are set
     if (params && typeof params === 'object') {
       // make sure all default params are defined

--- a/logger.js
+++ b/logger.js
@@ -1,24 +1,23 @@
-const defaults = require('./defaults.json')
-const emoji = require('node-emoji')
-const toArray = require('lodash.toarray')
 const util = require('util')
 const winston = require('winston')
+require('colors')
+const colors = require('colors/safe')
+
+const defaults = require('./defaults.json')
 const { combine, printf } = winston.format
 
 // transports object to easily override settings
 const transports = {
   console: new winston.transports.Console({
-    stderrLevels: ['error', 'warn'],
-    json: false,
-    colorize: true
+    stderrLevels: ['error', 'warn']
   })
 }
 
 // logger module
-const logger = winston.createLogger({
+const wLogger = winston.createLogger({
   // clean output instead of winstons default
   format: combine(
-    printf(info => `${info.message}`)
+    printf(info => info.message)
   ),
   // basic console transport set-up
   transports: [
@@ -29,55 +28,39 @@ const logger = winston.createLogger({
 /**
  * Takes in an input of arguments which are parsed, concatenated, and returned back as a string.
  * @param {object} input - Objet of arguments to be parsed
- * @param {string} type - Accepts type 'error', 'warn', or null to prepend the log type to the returning string.
- * @param {boolean} enableEmoji - If the returning string should contain emojis or remove them
+ * @param {boolean} enablePrefix - If the returning string should contain a prefix or remove them
+ * @param {string} prefix - a string that is prepended to the returning string.
  * @returns {string} - Returns the parsed and concatenated string of arguments
  */
-function argumentsToString (input, type, enableEmoji) {
+function argumentsToString (input, enablePrefix, prefix) {
   let str = ''
-  let args = Array.prototype.slice.call(input)
-  if (typeof args[0] === 'string' && args[0].length !== 0 && (type === 'warn' || type === 'error')) {
-    if ((type === 'warn' || type === 'error') && enableEmoji && !emoji.which(args[0])) {
-      str += type === 'error' ? '❌  ' : '⚠️  '
-    } else if (!enableEmoji) {
-      str += type === 'error' ? 'error: ' : 'warning: '
-    }
-  }
-  for (let k in args) {
-    if (typeof args[k] === 'string') {
-      if (enableEmoji && emoji.which(args[k])) {
-        str += args[k] + '  '
-      } else if (!enableEmoji) {
-        if (!emoji.which(args[k])) {
-          str += removeEmojis(args[k]) + ' '
-        }
-      } else {
-        str += args[k] + ' '
-      }
-    } else {
-      str += util.inspect(args[k], false, null, true) + ' '
-    }
-  }
-  return str
-}
+  let args = Object.values(input)
 
-/**
- * Removes emojis and 1 proceeding space if one exists
- * Ex: 'Test 🌗 String' would be 'Test String'
- * @param {string} str - String to remove emojis from
- * @returns {String} - String with the emojis removed
- */
-function removeEmojis (str) {
-  let words = toArray(str)
-  for (let x = words.length - 1; x >= 0; x--) {
-    if (emoji.findByCode(words[x])) {
-      words[x] = ''
-      if (words[x + 1] === ' ') {
-        words[x + 1] = ''
-      }
+  if (enablePrefix && typeof args[0] === 'string' && args.length > 1) {
+    str += args[0] + '  '
+  } else if (
+    typeof args[0] === 'string' && enablePrefix &&
+    (prefix !== '' && prefix !== false && prefix !== null && prefix !== undefined)
+  ) {
+    str += prefix + '  ' + args[0]
+  } else if (args.length === 1) {
+    if (typeof args[0] === 'string') {
+      str += args[0] + ' '
+    } else {
+      str += util.inspect(args[0], false, null, false) + ' '
     }
   }
-  return words.join('')
+
+  let rest = args.slice(1)
+
+  for (let k in rest) {
+    if (typeof rest[k] === 'string') {
+      str += rest[k] + ' '
+    } else {
+      str += util.inspect(rest[k], false, null, false) + ' '
+    }
+  }
+  return str.trimRight()
 }
 
 function setParams (params) {
@@ -85,42 +68,55 @@ function setParams (params) {
   // loop params and assign values
   for (let key in params) {
     if (defaults[key]) {
-      if (key === 'emoji') {
+      if (key === 'enablePrefix') {
         newParams[key] = typeof params[key] === 'boolean' ? params[key] : defaults[key]
       } else if (key === 'disable') {
         newParams[key] = Array.isArray(params[key]) ? params[key] : defaults[key]
       } else if (typeof params[key] === 'object') {
+        let { type, enable, prefix, color } = params[key]
         newParams[key] = {
-          type: (params[key]['type'] && typeof params[key]['type'] === 'string') ? params[key]['type'] : defaults[key]['type'],
-          enable: (params[key]['enable'] && typeof params[key]['enable'] === 'boolean') ? params[key]['enable'] : defaults[key]['enable'],
-          prefix: (params[key]['prefix'] && (typeof params[key]['prefix'] === 'string' || typeof params[key]['prefix'] === 'boolean')) ? params[key]['prefix'] : defaults[key]['prefix']
+          type: validateType(type) ? type : defaults[key].type,
+          enable: validateEnable(enable) ? enable : defaults[key].enable,
+          prefix: validatePrefix(prefix) ? prefix : defaults[key].prefix,
+          color: validateColor(color) ? color : defaults[key].color
         }
       } else if (typeof params[key] === 'boolean') {
         newParams[key] = {
-          type: defaults[key]['type'],
+          type: defaults[key].type,
           enable: params[key],
-          prefix: defaults[key]['prefix']
+          prefix: defaults[key].prefix,
+          color: false
         }
       }
     } else {
       if (typeof params[key] === 'object') {
+        let { type, enable, prefix, color } = params[key]
         newParams[key] = {
-          type: (params[key]['type'] && typeof params[key]['type'] === 'string') ? params[key]['type'] : 'info',
-          enable: (params[key]['enable'] && typeof params[key]['enable'] === 'boolean') ? params[key]['enable'] : true,
-          prefix: (params[key]['prefix'] && (typeof params[key]['prefix'] === 'string' || typeof params[key]['prefix'] === 'boolean')) ? params[key]['prefix'] : false
+          type: validateType(type) ? type : 'info',
+          enable: validateEnable(enable) ? enable : true,
+          prefix: validatePrefix(prefix) ? prefix : false,
+          color: validateColor(color) ? color : false
         }
       } else if (typeof params[key] === 'boolean') {
         newParams[key] = {
           type: 'info',
           enable: params[key],
-          prefix: false
+          prefix: false,
+          color: false
         }
+      } else if (key === 'disable') {
+        newParams[key] = params[key]
       }
     }
   }
+
+  if (process.env['ROOSEVELT_LOGGER_DISABLE_PREFIX'] === 'true') {
+    newParams.enablePrefix = false
+  }
+
   // loop defaults to make sure the newParams contains all default log types
   for (let key in defaults) {
-    if (!newParams[key]) {
+    if (newParams[key] === undefined) {
       newParams[key] = defaults[key]
     }
   }
@@ -129,105 +125,118 @@ function setParams (params) {
 
 class Logger {
   constructor (params) {
-    params = setParams(params)
+    this.params = setParams(params)
+    params = this.params
     // check to see if parameters are set
     if (params && typeof params === 'object') {
-      // make sure all default params are defined
-      for (let param in defaults) {
-        if (params[param] === undefined) {
-          params[param] = defaults[param]
-        }
-      }
       // iterate over params
       for (let key in params) {
         // check if the param is already a key in the defaults
         if (key in defaults) {
           // set the value for the default param
-          switch (key) {
-            case 'info':
-              this.info = params[key]
-              break
-            case 'warnings':
-              this.enableWarnings = params[key]
-              break
-            case 'verbose':
-              this.enableVerbose = params[key]
-              break
-            case 'emoji':
-              this.enableEmoji = params[key]
+          if (key === 'disable') {
+            // loop through array of args in the disable param
+            for (let env in params[key]) {
+              // if the arg is set to true/"true" in process.env or it's the env in process.env.NODE_ENV, supress the logs
+              if (process.env.NODE_ENV === params[key][env] || process.env[params[key][env]] === 'true') {
+                transports.console.silent = true
+              }
+            }
           }
-        } else if (key === 'disable') {
-          // loop through array of args in the disable param
-          for (let env in params[key]) {
-            // if the arg is set to true/"true" in process.env or it's the env in process.env.NODE_ENV, supress the logs
-            if (process.env.NODE_ENV === params[key][env] || process.env[params[key][env]] === true || process.env[params[key][env]] === 'true') {
-              transports.console.silent = true
+
+          if (['info', 'warn', 'verbose', 'error'].includes(key)) {
+            let { enablePrefix } = params
+            let { enable, type, color } = params[key]
+
+            this[key] = function () {
+              // log if the param is set to true
+              if (enable !== 'false' && enable !== false) {
+                // parse the log arguments
+                let logs = argumentsToString(arguments, enablePrefix, params[key]['prefix'])
+                // send the log level and message to winston for logging
+                if (color === false) {
+                  wLogger.log({ level: type, message: logs })
+                } else {
+                  wLogger.log({ level: type, message: colors[color](logs) })
+                }
+              }
             }
           }
         } else {
           // the param is a new key that's not one of the defaults
           let enable
           let type
-          let emoji
+          let color
+          let { enablePrefix } = params
+
           // check if the new key is an object
           if (typeof params[key] === 'object') {
             // assign values. if enable isn't set, set it to true
-            enable = (params[key]['enable'] !== undefined) ? params[key]['enable'] : true
-            type = params[key]['type'] || 'info'
-            emoji = typeof params.emoji !== 'undefined' ? params.emoji : true
+            enable = params[key].enable
+            type = params[key].type
+            color = (typeof params[key].color === 'undefined')
+              ? (() => {
+                switch (type) {
+                  case 'warn':
+                    return 'yellow'
+                  case 'error':
+                    return 'red'
+                  default:
+                    return false
+                }
+              })()
+              : params[key].color
           } else {
             // if it's not an object set enable
             enable = params[key]
             type = 'info'
-            emoji = typeof params.emoji !== 'undefined' ? params.emoji : true
+            color = false
           }
           // create a function for the new param
           this[key] = function () {
             // log if the param is set to true
             if (enable !== 'false' && enable !== false) {
               // parse the log arguments
-              let logs = argumentsToString(arguments, type, emoji)
+              let logs = argumentsToString(arguments, enablePrefix, params[key]['prefix'])
               // send the log level and message to winston for logging
-              logger.log({ level: type, message: logs })
+              if (color === false) {
+                wLogger.log({ level: type, message: logs })
+              } else {
+                wLogger.log({ level: type, message: colors[color](logs) })
+              }
             }
           }
         }
       }
-    } else {
-      // if there are no parameters set then use the defaults
-      this.info = defaults.info
-      this.enableWarnings = defaults.warnings
-      this.enableVerbose = defaults.verbose
-      this.enableEmoji = defaults.emoji
     }
-  }
 
-  // default log types
-  // info logs
-  log () {
-    if (this.info !== 'false' && this.info !== false) {
-      logger.log({ level: 'info', message: argumentsToString(arguments, null, this.enableEmoji) })
-    }
-  }
-
-  // warning logs
-  warn () {
-    if (this.enableWarnings !== 'false' && this.enableWarnings !== false) {
-      logger.log({ level: 'warn', message: argumentsToString(arguments, 'warn', this.enableEmoji) })
-    }
-  }
-
-  // verbose logs
-  verbose () {
-    if (this.enableVerbose !== 'false' && this.enableVerbose !== false) {
-      logger.log({ level: 'info', message: argumentsToString(arguments, null, this.enableEmoji) })
-    }
-  }
-
-  // error logs (always on by default)
-  error () {
-    logger.log({ level: 'error', message: argumentsToString(arguments, 'error', this.enableEmoji) })
+    // create log function to map to logger.info
+    this.log = this.info
   }
 }
 
-module.exports = (params) => new Logger(params)
+function validateType (type) {
+  return type !== undefined && typeof type === 'string'
+}
+
+function validateEnable (enableBool) {
+  return enableBool !== undefined && typeof enableBool === 'boolean'
+}
+
+function validatePrefix (prefix) {
+  return prefix !== undefined && (typeof prefix === 'string' || typeof prefix === 'boolean')
+}
+
+function validateColor (color) {
+  return color !== undefined && (typeof color === 'string' || typeof color === 'boolean')
+}
+
+module.exports = createLogger
+
+function createLogger (params) {
+  return new Logger(params)
+}
+
+createLogger.winston = winston
+createLogger.winstonLogger = wLogger
+createLogger.transports = transports

--- a/logger.js
+++ b/logger.js
@@ -36,38 +36,43 @@ function argumentsToString (input, enablePrefix, prefix) {
   let str = ''
   let args = Object.values(input)
 
+  // Logic to check if first arg is a prefix
   if (enablePrefix && typeof args[0] === 'string' && args.length > 1) {
+    // Custom prefix
     str += args[0] + '  '
   } else if (
-    typeof args[0] === 'string' && enablePrefix &&
-    (prefix !== '' && prefix !== false && prefix !== null && prefix !== undefined)
+    enablePrefix &&
+    (prefix !== '' && prefix !== false && prefix !== null && prefix !== undefined && prefix !== '')
   ) {
-    str += prefix + '  ' + args[0]
+    // Defualt prefix
+    let arg0 = (typeof args[0] === 'string') ? args[0] : util.inspect(args[0], false, null, false)
+    str += prefix + '  ' + arg0
   } else if (args.length === 1) {
-    if (typeof args[0] === 'string') {
-      str += args[0] + ' '
-    } else {
-      str += util.inspect(args[0], false, null, false) + ' '
-    }
+    // No prefix
+    let arg0 = (typeof args[0] === 'string') ? args[0] : util.inspect(args[0], false, null, false)
+    str += arg0 + ' '
   }
 
+  // Print out remaining args
   let rest = args.slice(1)
-
   for (let k in rest) {
-    if (typeof rest[k] === 'string') {
-      str += rest[k] + ' '
-    } else {
-      str += util.inspect(rest[k], false, null, false) + ' '
-    }
+    let arg = (typeof rest[k] === 'string') ? rest[k] : util.inspect(rest[k], false, null, false)
+    str += arg + ' '
   }
   return str.trimRight()
 }
 
+/**
+ * Generate params object based on params in logger constructor and defaults
+ * @param {object} params - params in logger constructor
+ * @returns {object} - fleshed out params object
+ */
 function setParams (params) {
   let newParams = {}
   // loop params and assign values
   for (let key in params) {
     if (defaults[key]) {
+      // Setting up newParams[key] for a property in defaults.json
       if (key === 'enablePrefix') {
         newParams[key] = typeof params[key] === 'boolean' ? params[key] : defaults[key]
       } else if (key === 'disable') {
@@ -89,20 +94,21 @@ function setParams (params) {
         }
       }
     } else {
+      // Setting up newParams[key] for a custom property
       if (typeof params[key] === 'object') {
         let { type, enable, prefix, color } = params[key]
         newParams[key] = {
           type: validateType(type) ? type : 'info',
           enable: validateEnable(enable) ? enable : true,
-          prefix: validatePrefix(prefix) ? prefix : false,
-          color: validateColor(color) ? color : false
+          prefix: validatePrefix(prefix) ? prefix : undefined,
+          color: validateColor(color) ? color : undefined
         }
       } else if (typeof params[key] === 'boolean') {
         newParams[key] = {
           type: 'info',
           enable: params[key],
-          prefix: false,
-          color: false
+          prefix: undefined,
+          color: undefined
         }
       } else if (key === 'disable') {
         newParams[key] = params[key]
@@ -110,7 +116,7 @@ function setParams (params) {
     }
   }
 
-  if (process.env['ROOSEVELT_LOGGER_DISABLE_PREFIX'] === 'true') {
+  if (process.env['ROOSEVELT_LOGGER_ENABLE_PREFIX'] === 'false') {
     newParams.enablePrefix = false
   }
 
@@ -123,112 +129,142 @@ function setParams (params) {
   return newParams
 }
 
-class Logger {
-  constructor (params) {
-    this.params = setParams(params)
-    params = this.params
-    // check to see if parameters are set
-    if (params && typeof params === 'object') {
-      // iterate over params
-      for (let key in params) {
-        // check if the param is already a key in the defaults
-        if (key in defaults) {
-          // set the value for the default param
-          if (key === 'disable') {
-            // loop through array of args in the disable param
-            for (let env in params[key]) {
-              // if the arg is set to true/"true" in process.env or it's the env in process.env.NODE_ENV, supress the logs
-              if (process.env.NODE_ENV === params[key][env] || process.env[params[key][env]] === 'true') {
-                transports.console.silent = true
-              }
-            }
-          }
-
-          if (['info', 'warn', 'verbose', 'error'].includes(key)) {
-            let { enablePrefix } = params
-            let { enable, type, color } = params[key]
-
-            this[key] = function () {
-              // log if the param is set to true
-              if (enable !== 'false' && enable !== false) {
-                // parse the log arguments
-                let logs = argumentsToString(arguments, enablePrefix, params[key]['prefix'])
-                // send the log level and message to winston for logging
-                if (color === false) {
-                  wLogger.log({ level: type, message: logs })
-                } else {
-                  wLogger.log({ level: type, message: colors[color](logs) })
-                }
-              }
-            }
-          }
-        } else {
-          // the param is a new key that's not one of the defaults
-          let enable
-          let type
-          let color
-          let { enablePrefix } = params
-
-          // check if the new key is an object
-          if (typeof params[key] === 'object') {
-            // assign values. if enable isn't set, set it to true
-            enable = params[key].enable
-            type = params[key].type
-            color = (typeof params[key].color === 'undefined')
-              ? (() => {
-                switch (type) {
-                  case 'warn':
-                    return 'yellow'
-                  case 'error':
-                    return 'red'
-                  default:
-                    return false
-                }
-              })()
-              : params[key].color
-          } else {
-            // if it's not an object set enable
-            enable = params[key]
-            type = 'info'
-            color = false
-          }
-          // create a function for the new param
-          this[key] = function () {
-            // log if the param is set to true
-            if (enable !== 'false' && enable !== false) {
-              // parse the log arguments
-              let logs = argumentsToString(arguments, enablePrefix, params[key]['prefix'])
-              // send the log level and message to winston for logging
-              if (color === false) {
-                wLogger.log({ level: type, message: logs })
-              } else {
-                wLogger.log({ level: type, message: colors[color](logs) })
-              }
+function Logger (params) {
+  this.params = setParams(params)
+  params = this.params
+  // check to see if parameters are set
+  if (params && typeof params === 'object') {
+    // iterate over params
+    for (let key in params) {
+      // check if the param is already a key in the defaults
+      if (key in defaults) {
+        // set the value for the default param
+        if (key === 'disable') {
+          // loop through array of args in the disable param
+          for (let env in params[key]) {
+            // if the arg is set to true/"true" in process.env or it's the env in process.env.NODE_ENV, supress the logs
+            if (process.env.NODE_ENV === params[key][env] || process.env[params[key][env]] === 'true') {
+              transports.console.silent = true
             }
           }
         }
+
+        if (['info', 'warn', 'verbose', 'error'].includes(key)) {
+          let { enablePrefix } = params
+          let { enable, type, color } = params[key]
+
+          this[key] = function (...args) {
+            createLog(args, enable, enablePrefix, params[key].prefix, color, type)
+          }
+        }
+      } else {
+        // the param is a new key that's not one of the defaults
+        let enable
+        let type
+        let color
+        let prefix
+        let { enablePrefix } = params
+
+        // check if the new key is an object
+        if (typeof params[key] === 'object') {
+          // assign values. if enable isn't set, set it to true
+          enable = params[key].enable
+          type = params[key].type
+          prefix = (typeof params[key].prefix === 'undefined')
+            ? (() => {
+              switch (type) {
+                case 'warn':
+                  return '⚠️ '
+                case 'error':
+                  return '❌'
+                default:
+                  return false
+              }
+            })()
+            : params[key].prefix
+          color = (typeof params[key].color === 'undefined')
+            ? (() => {
+              switch (type) {
+                case 'warn':
+                  return 'yellow'
+                case 'error':
+                  return 'red'
+                default:
+                  return false
+              }
+            })()
+            : params[key].color
+        } else {
+          // if it's not an object set enable
+          enable = params[key]
+          type = 'info'
+          color = false
+        }
+        // create a function for the new param
+        this[key] = function (...args) {
+          createLog(args, enable, enablePrefix, prefix, color, type)
+        }
       }
     }
-
-    // create log function to map to logger.info
-    this.log = this.info
   }
+
+  // create log function to map to logger.info
+  this.log = this.info
 }
 
+/**
+ * Check the 'type' property is defined and a string
+ * @param {string} type - type of a log type
+ */
 function validateType (type) {
   return type !== undefined && typeof type === 'string'
 }
 
+/**
+ * Check the 'enable' property is defined and a boolean
+ * @param {boolean} enableBool - boolean to decide if a specific log type is enabled
+ */
 function validateEnable (enableBool) {
   return enableBool !== undefined && typeof enableBool === 'boolean'
 }
 
+/**
+ * Check the 'prefix' property is defined and a string or boolean
+ * @param {string|boolean} prefix - prefix of a log type
+ */
 function validatePrefix (prefix) {
   return prefix !== undefined && (typeof prefix === 'string' || typeof prefix === 'boolean')
 }
 
+/**
+ * Check the 'color' property is defined and a string or boolean
+ * @param {string|boolean} color - custom color of a log type
+ */
 function validateColor (color) {
   return color !== undefined && (typeof color === 'string' || typeof color === 'boolean')
+}
+
+/**
+ * Parse send a log to the logger
+ * @param {Array<*>} args - args to pass to the interal logger
+ * @param {boolean} enable - flag to state if this should be logged
+ * @param {boolean} enablePrefix - flag to state if the prefix should be printed
+ * @param {string} prefix - the prefix for this log entry
+ * @param {string} color - the color for this log entry
+ * @param {string} type - the internal log level type for winston
+ */
+function createLog (args, enable, enablePrefix, prefix, color, type) {
+  // log if the param is set to true
+  if (enable !== 'false' && enable !== false) {
+    // parse the log arguments
+    let logs = argumentsToString(args, enablePrefix, prefix)
+    // send the log level and message to winston for logging
+    if (color === false) {
+      wLogger.log({ level: type, message: logs })
+    } else {
+      wLogger.log({ level: type, message: colors[color](logs) })
+    }
+  }
 }
 
 module.exports = createLogger

--- a/package-lock.json
+++ b/package-lock.json
@@ -1137,9 +1137,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.10.0.tgz",
-      "integrity": "sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
+      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1151,7 +1151,7 @@
         "eslint-scope": "^4.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
+        "espree": "^4.0.0",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
@@ -1161,6 +1161,7 @@
         "ignore": "^4.0.6",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.1.0",
+        "is-resolvable": "^1.1.0",
         "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
@@ -1401,9 +1402,9 @@
       "dev": true
     },
     "espree": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.2",
@@ -2761,11 +2762,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
-    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -3024,14 +3020,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-emoji": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-      "requires": {
-        "lodash.toarray": "^4.4.0"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Intuitive, attractive logger for Node.js applications based on Winston.",
   "author": "Roosevelt Framework Team <rooseveltframework@gmail.com>",
   "contributors": [
-    "Michael Mulligan <mkmllgn@gmail.com>"
+    "Michael Mulligan <mkmllgn@gmail.com>",
+    "Benjamin Lannon <benjamin@lannonbr.com>"
   ],
   "version": "0.1.0",
   "homepage": "https://github.com/rooseveltframework/roosevelt-logger",
@@ -14,19 +15,18 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "lodash.toarray": "^4.4.0",
-    "node-emoji": "^1.8.1",
-    "winston": "^3.1.0"
+    "colors": "1.3.3",
+    "winston": "3.1.0"
   },
   "devDependencies": {
-    "codecov": "^3.1.0",
-    "eslint": "^5.9.0",
-    "eslint-plugin-mocha": "^5.2.0",
-    "husky": "^1.2.0",
-    "lint-staged": "^8.1.0",
-    "mocha": "^5.2.0",
-    "nyc": "^13.1.0",
-    "standard": "^12.0.1"
+    "codecov": "3.1.0",
+    "eslint": "5.9.0",
+    "eslint-plugin-mocha": "5.2.0",
+    "husky": "1.2.0",
+    "lint-staged": "8.1.0",
+    "mocha": "5.2.0",
+    "nyc": "13.1.0",
+    "standard": "12.0.1"
   },
   "eslintConfig": {
     "parserOptions": {

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -9,9 +9,9 @@ describe('Logger Tests', function () {
   // Parameters to pass to the logger
   let configs = {
     'info': true,
-    'warnings': true,
+    'warn': true,
     'verbose': true,
-    'emoji': true,
+    'enablePrefix': true,
     'custom1': true,
     'custom2': {
       'type': 'info'
@@ -71,7 +71,6 @@ describe('Logger Tests', function () {
     logger.error('This should have an emoji prefix')
     logger.warn('This should also have an emoji prefix')
     logger.error('❤️', 'This should not add a prefix because one is already there')
-    logger.custom4('This log is custom', '⚠️', 'with an emoji in the middle')
 
     // disabled logs
     logger.custom5('Should not have an output 1')
@@ -88,13 +87,12 @@ describe('Logger Tests', function () {
     assert.strictEqual(logs[3].includes('Should be of type info'), true, 'The logger did not output a custom log')
     assert.strictEqual(logs[4].includes('Single object key type param'), true, 'The logger did not output a custom log')
     assert.strictEqual(logs[5].includes('Single object key enabled param'), true, 'The logger did not output a custom log')
-    assert.strictEqual(logs[6].includes(util.inspect({ 'this': 'is an object' }, false, null, true)), true, 'The logger did not output an object')
+    assert.strictEqual(logs[6].includes(util.inspect({ 'this': 'is an object' }, false, null, false)), true, 'The logger did not output an object')
 
     // error log assertions
     assert.strictEqual(errors[0].includes('❌  This should have an emoji prefix'), true, 'The logger did not automatically add an emoji to the error log')
-    assert.strictEqual(errors[1].includes('⚠️  This should also have an emoji prefix'), true, 'The logger did not automatically add an emoji to the error log')
+    assert.strictEqual(errors[1].includes('⚠️   This should also have an emoji prefix'), true, 'The logger did not automatically add an emoji to the error log')
     assert.strictEqual(errors[2].includes('❤️  This should not add a prefix because one is already there'), true, 'The logger added an emoji prefix')
-    assert.strictEqual(errors[3].includes('This log is custom ⚠️  with an emoji in the middle'), true, 'The logger did not output a custom log')
 
     // disabled log assertions
     if (typeof logs[7] !== 'undefined') {
@@ -142,7 +140,7 @@ describe('Logger Tests', function () {
 
     // error log assertions
     assert.strictEqual(errors[0].includes('❌  Error Log'), true, 'The logger did not output an error log')
-    assert.strictEqual(errors[1].includes('⚠️  Warning Log'), true, 'The logger did not output a warning log')
+    assert.strictEqual(errors[1].includes('⚠️   Warning Log'), true, 'The logger did not output a warning log')
 
     // exit test
     done()
@@ -174,16 +172,16 @@ describe('Logger Tests', function () {
     assert.strictEqual(logs[1].includes(''), true, 'The logger failed to output an emty string')
     assert.strictEqual(logs[2].includes('123'), true, 'The logger did not output a number')
     // use inspect for objects
-    assert.strictEqual(logs[3].includes(util.inspect({ key: 'value' }, false, null, true)), true, 'The logger did not output an object')
-    assert.strictEqual(logs[4].includes(util.inspect([ 'array' ], false, null, true)), true, 'The logger did not output an array')
+    assert.strictEqual(logs[3].includes('{ key: \'value\' }'), true, 'The logger did not output an object')
+    assert.strictEqual(logs[4].includes(util.inspect([ 'array' ], false, null, false)), true, 'The logger did not output an array')
 
     // exit test
     done()
   })
 
-  it('Should disable emojis when emoji is set to false', function (done) {
+  it('Should remove prefixes when enablePrefix is set to false', function (done) {
     // require the logger for this test
-    configs.emoji = false
+    configs.enablePrefix = false
     const logger = require('../../logger')(configs)
 
     // variable to store the logs
@@ -223,10 +221,10 @@ describe('Logger Tests', function () {
     assert.strictEqual(logs[3].includes('Custom2'), true, 'The logger did not remove the emoji in logger.custom2()')
 
     // error log assertions
-    assert.strictEqual(errors[0].includes('error: Error Log'), true, 'The logger did not remove the emoji in logger.error()')
-    assert.strictEqual(errors[1].includes('warning: Warning Log'), true, 'The logger did not remove the emoji in logger.warn()')
-    assert.strictEqual(errors[2].includes('error: Error Log'), true, 'The logger did not remove the emoji in logger.error()')
-    assert.strictEqual(errors[3].includes('warning: Warning Log'), true, 'The logger did not remove the emoji in logger.warn()')
+    assert.strictEqual(errors[0].includes('Error Log'), true, 'The logger did not remove the emoji in logger.error()')
+    assert.strictEqual(errors[1].includes('Warning Log'), true, 'The logger did not remove the emoji in logger.warn()')
+    assert.strictEqual(errors[2].includes('Error Log'), true, 'The logger did not remove the emoji in logger.error()')
+    assert.strictEqual(errors[3].includes('Warning Log'), true, 'The logger did not remove the emoji in logger.warn()')
 
     // exit test
     done()


### PR DESCRIPTION
This PR will close #3, close #7, and close #8

- Added `colors` npm package
- Continued work on @mulligan121's progress with the config objects for custom log types
- Pulled in @kethinov's changes from #6 and added remaining docs changes (This likely will need another runthrough of cleaning up the readme)
- Exposed various internal modules / variables
  - winston: the instance of the `winston` logger.
  - winstonLogger: the specific logger created from the `winston.createLogger` method call
  - transports: the default transports enabled by roosevelt-logger (currently only `console`)
