### PR TITLE
The big refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Next version
 
-- Put changes here...
+- Full module refactor.
+- Change to class based instantiation.
+  - Add `enableLogger()` and `disableLogger()` methods.
+  - Add `enablePrefix()` and `disablePrefix()` methods.
+  - Add `createNewMethod()` method.
+- Overhaul API
 
 ## 0.1.0
 
 - Initial version.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Change to class based instantiation.
   - Add `enableLogger()` and `disableLogger()` methods.
   - Add `enablePrefix()` and `disablePrefix()` methods.
-  - Add `createNewMethod()` method.
+  - Add `createLogMethod()` method.
 - Overhaul API
 
 ## 0.1.0

--- a/README.md
+++ b/README.md
@@ -13,65 +13,56 @@ First declare `roosevelt-logger` as a dependency in your app.
 Require the package into your application and call its constructor:
 
 ```js
-const logger = require('roosevelt-logger')()
+const Logger = require('roosevelt-logger')
+const logger = new Logger()
 
 logger.log('some info')
+//=> some info
+
 logger.warn('a warning')
+//=> ⚠️  a warning
+
 logger.error('an error')
+//=> ❌  an error
+
 logger.verbose('noisy log only displayed when verbose is enabled')
+//=>
+
 logger.log('✅', 'log prepended with a custom emoji or other string')
-
-```
-
-This would output the following:
-
-```
-some info
-⚠️  a warning
-❌  an error
-✅  log prepended with a custom emoji or other string
+//=> ✅  log prepended with a custom emoji or other string
 ```
 
 ## Configure logger
 
-Optionally you can pass the logger a set of configs. Each config type that maps to a default log type can be set to either a boolean to enable / disable the log or an object:
+Optionally you can pass the logger a set of configs.
 
-- `info` *[Boolean]*: Enable regular logs.
+- `methods`: A set of configs that represent logger methods that are available to use. Each config type that maps to a default log type can be set to either a boolean to enable / disable the log or an object:
 
-  - Default: `true`.
+  - `info` *[Boolean]*: Enable regular logs.
 
-- `warnings` *[Boolean]*: Enable logging of warnings.
+    - Default: `true`.
 
-  - Default: `true`.
+  - `warn` *[Boolean]*: Enable logging of warnings.
 
-- `verbose` *[Boolean]*: Enable verbose (noisy) logging.
+    - Default: `true`.
 
-  - Default: `false`.
+  - `verbose` *[Boolean]*: Enable verbose (noisy) logging.
 
-- `disable` *[Array of Strings]*: Disable all logging in certain environments. Each entry can be either an environment variable or the value of the `NODE_ENV` environment variable.
+    - Default: `false`.
 
-  - Default: `[]`.
-  - Example usage:
-    - `['LOADED_MOCHA_OPTS']`: Disables logger when app is being run by [Mocha](https://mochajs.org/).
-    - `['production']`: Disables logger when `NODE_ENV` is set to `production`.
+  - Custom log type *[Object]*: You can also define your own log types and specify what native log type it maps to.
 
-- `enablePrefix` *[Boolean]*: Enable prefixes which can contain emojis or other strings to be prepended to logs. This can also be toggled with the `ROOSEVELT_LOGGER_ENABLE_PREFIX` environment variable.
-
-- Custom log type *[Object]*: You can also define your own log types and specify what native log type it maps to.
-
-  - API:
-
-    - `enable` *[Boolean]*: Enable this custom log.
-      - Default:  `true`.
-    - `type` *[String]*: What type of native log this custom log maps to.
-      - Default: `info`.
-      - Allowed values: `info`, `warn`, or `error`.
-    - `prefix`: *[String]*: The string that prefixes any log entry. If not set or set to a falsy value (e.g. `null`, an empty string, etc), the prefix will be disabled.
-      - Default for warnings: `⚠️`.
-      - Default for errors: `❌`.
-    - `color`: *[String]*: The color that the text will be set to using [colors](https://www.npmjs.com/package/colors) npm package. If not set, it will use whatever the default color is for the native type selected.
-
-  - Example: Simple custom type example for a new log type called `dbError`:
+    - API:
+      - `enable` *[Boolean]*: Enable this custom log.
+        - Default:  `true`.
+      - `type` *[String]*: What type of native log this custom log maps to.
+        - Default: `info`.
+        - Allowed values: `info`, `warn`, or `error`.
+      - `prefix`: *[String]*: The string that prefixes any log entry. If not set or set to a falsy value (e.g. `null`, an empty string, etc), the prefix will be disabled.
+        - Default for warnings: `⚠️`.
+        - Default for errors: `❌`.
+      - `color`: *[String]*: The color that the text will be set to using [colors](https://www.npmjs.com/package/colors) npm package. If not set, it will use whatever the default color is for the native type selected.
+    - Example: Simple custom type example for a new log type called `dbError`:
 
     ```json
     {
@@ -81,7 +72,7 @@ Optionally you can pass the logger a set of configs. Each config type that maps 
 
     - The above example would create a custom log type called `dbError`. Since no params are supplied to it, it defaults to being enabled and defaults to log type `info` with no prefix or color.
 
-  - Complex custom type example:
+    - Complex custom type example:
 
     ```json
     {
@@ -93,6 +84,16 @@ Optionally you can pass the logger a set of configs. Each config type that maps 
       }
     }
     ```
+
+- `params`: Configuration that applies to all logger methods:
+
+  - `disable` *[Array of Strings]*: Disable all logging in certain environments. Each entry can be either an environment variable or the value of the `NODE_ENV` environment variable.
+  - Default: `[]`.
+    - Example usage:
+      - `['LOADED_MOCHA_OPTS']`: Disables logger when app is being run by [Mocha](https://mochajs.org/).
+      - `['production']`: Disables logger when `NODE_ENV` is set to `production`.
+
+  - `enablePrefix` *[Boolean]*: Enable prefixes which can contain emojis or other strings to be prepended to logs. This can also be toggled with the `ROOSEVELT_LOGGER_ENABLE_PREFIX` environment variable.
 
 ## Usage with custom configs
 
@@ -129,7 +130,57 @@ noisy log only displayed when verbose is enabled
 
 In addition to the constructor, `roosevelt-logger` exposes the following properties:
 
-* `winston`: *[Function]*: The [Winston](https://www.npmjs.com/package/winston) module that `roosevelt-logger` uses internally.
-* `winstonInstance`: The specific [Winston](https://www.npmjs.com/package/winston) object instance instantiated by `roosevelt-logger`.
-* `transports`: The default [Winston transports](https://github.com/winstonjs/winston#transports) enabled by `roosevelt-logger`.
+### .winston()
 
+The [Winston](https://www.npmjs.com/package/winston) module that `roosevelt-logger` uses internally.
+
+### .winstonInstance
+
+The specific [Winston](https://www.npmjs.com/package/winston) object instance instantiated by `roosevelt-logger`.\
+
+### .transports
+
+The default [Winston transports](https://github.com/winstonjs/winston#transports) enabled by `roosevelt-logger`.
+
+### .enableLogging()
+
+Programmatically enable the logger.
+
+### .disableLogging()
+
+Programmatically disable the logger.
+
+### .enablePrefix()
+
+Programmatically enable all log prefixes.
+
+### .disablePrefix()
+
+Programmatically disable all log prefixes.
+
+### .createLogMethod(config)
+
+Programmatically create a new logger method.
+
+- API:
+  - `name` *[String]*: New Logger method name.
+  - `type` *[String]*: What type of native log this custom log maps to.
+    - Default: `info`.
+    - Allowed values: `info`, `warn`, or `error`.
+  - `prefix`: *[String]*: The string that prefixes any log entry. If not set or set to a falsy value (e.g. `null`, an empty string, etc), the prefix will be disabled.
+    - Default for warnings: `⚠️`.
+    - Default for errors: `❌`.
+  - `color`: *[String]*: The color that the text will be set to using [colors](https://www.npmjs.com/package/colors) npm package. If not set, it will use whatever the default color is for the native type selected.
+- Example:
+
+```js
+  logger.createLogMethod({
+    name: 'dbError',
+    type: 'error'
+    prefix: '💥 ',
+    color: 'red'
+  })
+
+  logger.dbError('Our whole stack is in crisis mode!')
+  //=> 💥 Our whole stack is in crisis mode!
+```

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Programmatically disable all log prefixes.
 Programmatically create a new logger method.
 
 - API:
-  - `name` *[String]*: New Logger method name.
+  - `name` *[String]*: New logger method name.
   - `type` *[String]*: What type of native log this custom log maps to.
     - Default: `info`.
     - Allowed values: `info`, `warn`, or `error`.

--- a/README.md
+++ b/README.md
@@ -88,12 +88,13 @@ Optionally you can pass the logger a set of configs.
 - `params`: Configuration that applies to all logger methods:
 
   - `disable` *[Array of Strings]*: Disable all logging in certain environments. Each entry can be either an environment variable or the value of the `NODE_ENV` environment variable.
-  - Default: `[]`.
+    - Default: `[]`.
     - Example usage:
       - `['LOADED_MOCHA_OPTS']`: Disables logger when app is being run by [Mocha](https://mochajs.org/).
       - `['production']`: Disables logger when `NODE_ENV` is set to `production`.
 
   - `enablePrefix` *[Boolean]*: Enable prefixes which can contain emojis or other strings to be prepended to logs. This can also be toggled with the `ROOSEVELT_LOGGER_ENABLE_PREFIX` environment variable.
+    - Note: Due to lack of support for emojis in most windows terminals this param is disabled by default in windows. This can be overridden with the `ROOSEVELT_LOGGER_ENABLE_PREFIX` environment variable or `logger.enablePrefix()` method.
 
 ## Usage with custom configs
 
@@ -110,25 +111,22 @@ const logger = require('roosevelt-logger')({
 })
 
 logger.log('some info')
+//=> some info
+
 logger.warn('a warning')
+//=> ⚠️  a warning
+
 logger.error('an error')
+//=> ❌  an error
+
 logger.verbose('noisy log only displayed when verbose is enabled')
+//=> noisy log only displayed when verbose is enabled
+
 logger.dbError('custom log for database errors')
+//=> 🗄  custom log for database errors
 ```
 
-Output:
-
-```
-some info
-⚠️ a warning
-❌ an error
-noisy log only displayed when verbose is enabled
-🗄 custom log for database errors
-```
-
-## Properties of roosevelt-logger module
-
-In addition to the constructor, `roosevelt-logger` exposes the following properties:
+## Instance properties exposed by roosevelt-logger
 
 ### .winston()
 
@@ -177,7 +175,7 @@ Programmatically create a new logger method.
   logger.createLogMethod({
     name: 'dbError',
     type: 'error'
-    prefix: '💥 ',
+    prefix: '💥',
     color: 'red'
   })
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The [Winston](https://www.npmjs.com/package/winston) module that `roosevelt-logg
 
 ### .winstonInstance
 
-The specific [Winston](https://www.npmjs.com/package/winston) object instance instantiated by `roosevelt-logger`.\
+The specific [Winston](https://www.npmjs.com/package/winston) object instance instantiated by `roosevelt-logger`.
 
 ### .transports
 

--- a/defaults.json
+++ b/defaults.json
@@ -1,28 +1,32 @@
 {
-  "info": {
-    "type": "info",
-    "enable": true,
-    "prefix": false,
-    "color": false
+  "methods": {
+    "info": {
+      "type": "info",
+      "enable": true,
+      "prefix": false,
+      "color": false
+    },
+    "warn": {
+      "type": "warn",
+      "enable": true,
+      "prefix": "⚠️ ",
+      "color": "yellow"
+    },
+    "error": {
+      "type": "error",
+      "enable": true,
+      "prefix": "❌",
+      "color": "red"
+    },
+    "verbose": {
+      "type": "info",
+      "enable": false,
+      "prefix": false,
+      "color": false
+    }
   },
-  "warn": {
-    "type": "warn",
-    "enable": true,
-    "prefix": "⚠️ ",
-    "color": "yellow"
-  },
-  "error": {
-    "type": "error",
-    "enable": true,
-    "prefix": "❌",
-    "color": "red"
-  },
-  "verbose": {
-    "type": "info",
-    "enable": false,
-    "prefix": false,
-    "color": false
-  },
-  "enablePrefix": true,
-  "disable": []
+  "params": {
+    "enablePrefix": true,
+    "disable": []
+  }
 }

--- a/logger.js
+++ b/logger.js
@@ -309,7 +309,7 @@ function validateEnable (enableBool) {
  * @param {string} type - Type of a log type
  */
 function sanitizePrefix (prefix, type) {
-  // sanitize prefix
+  // check prefix validity
   let validPrefix = prefix !== undefined && (typeof prefix === 'string' || typeof prefix === 'boolean')
 
   // set to a default if invalid

--- a/logger.js
+++ b/logger.js
@@ -55,11 +55,10 @@ class Logger {
 
     // iterate over methods and bind each one to this class
     for (let key in methods) {
-      let { enablePrefix } = globals
       let { enable, type, prefix, color } = methods[key]
 
       this[key] = function (...args) {
-        this._createLog(args, enable, enablePrefix, prefix, color, type)
+        this._createLog(args, enable, globals.enablePrefix, prefix, color, type)
       }
     }
 
@@ -108,14 +107,14 @@ class Logger {
    * Disable logging prefix
    */
   disablePrefix () {
-    this.params.enablePrefix = false
+    this.params.params.enablePrefix = false
   }
 
   /**
    * Enable logging prefix
    */
   enablePrefix () {
-    this.params.enablePrefix = true
+    this.params.params.enablePrefix = true
   }
 
   /**
@@ -210,8 +209,18 @@ function setParams (params) {
     newParams.params.enablePrefix = defaults.params.enablePrefix
   }
 
-  // disable prefix via node env
-  if (process.env['ROOSEVELT_LOGGER_ENABLE_PREFIX'] === 'false') {
+  /**
+   * Disable prefixes in windows by default
+   * See: https://github.com/rooseveltframework/roosevelt-logger/issues/34 for more details
+   */
+  if (process.platform === 'win32') {
+    newParams.params.enablePrefix = false
+  }
+
+  // toggle prefix based on env
+  if (process.env['ROOSEVELT_LOGGER_ENABLE_PREFIX'] === 'true') {
+    newParams.params.enablePrefix = true
+  } else if (process.env['ROOSEVELT_LOGGER_ENABLE_PREFIX'] === 'false') {
     newParams.params.enablePrefix = false
   }
 

--- a/logger.js
+++ b/logger.js
@@ -1,56 +1,185 @@
+require('colors')
 const util = require('util')
 const winston = require('winston')
-require('colors')
 const colors = require('colors/safe')
-
 const defaults = require('./defaults.json')
 const { combine, printf } = winston.format
 
-// transports object to easily override settings
-const transports = {
-  console: new winston.transports.Console({
-    stderrLevels: ['error', 'warn']
-  })
+/** Class representing roosevelt-logger */
+class Logger {
+  /**
+   * Create a logger instance
+   * @param {object} params - Logger configuration
+   */
+  constructor (params) {
+    // ensure params is an object
+    params = params || {}
+
+    // bind parameters
+    this.params = setParams(params)
+    params = this.params
+    let globals = params.params
+    let methods = params.methods
+
+    // transports object to easily override settings
+    const transports = {
+      console: new winston.transports.Console({
+        stderrLevels: ['error', 'warn']
+      })
+    }
+
+    // logger module
+    const wLogger = winston.createLogger({
+      // clean output instead of winstons default
+      format: combine(
+        printf(info => info.message)
+      ),
+      // basic console transport set-up
+      transports: [
+        transports.console
+      ]
+    })
+
+    // expose the bare winston module as well as this instance of it
+    this.winston = winston
+    this.winstonInstance = wLogger
+    this.transports = transports
+
+    // iterate over global disable array
+    for (let env in globals.disable) {
+      // if the arg is set to true/"true" in process.env or it's the env in process.env.NODE_ENV, suppress all logs
+      if (process.env.NODE_ENV === globals.disable[env] || process.env[globals.disable[env]] === 'true') {
+        transports.console.silent = true
+      }
+    }
+
+    // iterate over methods and bind each one to this class
+    for (let key in methods) {
+      let { enablePrefix } = globals
+      let { enable, type, prefix, color } = methods[key]
+
+      this[key] = function (...args) {
+        this._createLog(args, enable, enablePrefix, prefix, color, type)
+      }
+    }
+
+    // create log function to map to logger.info
+    this.log = this.info
+  }
+
+  /**
+   * Parse log configuration and dispatch to winston logger instance
+   * @param {Array<*>} args - Args to pass to the interal logger
+   * @param {boolean} enable - Flag to state if this should be logged
+   * @param {boolean} enablePrefix - Flag to state if the prefix should be printed
+   * @param {string} prefix - The prefix for this log entry
+   * @param {string} color - The color for this log entry
+   * @param {string} type - The internal log level type for winston
+   */
+  _createLog (args, enable, enablePrefix, prefix, color, type) {
+    // log if the param is set to true
+    if (enable !== 'false' && enable !== false) {
+      // parse the log arguments
+      let logs = argumentsToString(args, enablePrefix, prefix)
+      // send the log level and message to winston for logging
+      if (color === false) {
+        this.winstonInstance.log({ level: type, message: logs })
+      } else {
+        this.winstonInstance.log({ level: type, message: colors[color](logs) })
+      }
+    }
+  }
+
+  /**
+   * Disable logging to console
+   */
+  disableLogging () {
+    this.transports.console.silent = true
+  }
+
+  /**
+   * Enable logging to console
+   */
+  enableLogging () {
+    this.transports.console.silent = false
+  }
+
+  /**
+   * Disable logging prefix
+   */
+  disablePrefix () {
+    this.params.enablePrefix = false
+  }
+
+  /**
+   * Enable logging prefix
+   */
+  enablePrefix () {
+    this.params.enablePrefix = true
+  }
+
+  /**
+   * Create a new logger method
+   * @param {object} params - Configuration for new logger method
+   */
+  createLogMethod (params) {
+    let name = params.name
+
+    // validate that the method name is a string
+    if (!name || typeof name !== 'string') {
+      console.error('❌ ', `Method name: ${name} invalid. Must be type string.`)
+      return
+    }
+
+    // validate and sanitize config
+    params = validateLoggerMethod(name, params)
+    let { type, prefix, color } = params
+
+    // bind new logger type to logger config
+    this.params[name] = {
+      type: type,
+      enable: true,
+      prefix: prefix,
+      color: color
+    }
+
+    // create a function for the new logger
+    this[name] = function (...args) {
+      this._createLog(args, true, this.params.enablePrefix, prefix, color, type)
+    }
+  }
 }
 
-// logger module
-const wLogger = winston.createLogger({
-  // clean output instead of winstons default
-  format: combine(
-    printf(info => info.message)
-  ),
-  // basic console transport set-up
-  transports: [
-    transports.console
-  ]
-})
+/**
+ * Utility Functions
+ */
 
 /**
  * Takes in an input of arguments which are parsed, concatenated, and returned back as a string.
- * @param {object} input - Objet of arguments to be parsed
+ * @param {object} input - Object of arguments to be parsed
  * @param {boolean} enablePrefix - If the returning string should contain a prefix or remove them
- * @param {string} prefix - a string that is prepended to the returning string.
+ * @param {string} prefix - A string that is prepended to the returning string.
  * @returns {string} - Returns the parsed and concatenated string of arguments
  */
 function argumentsToString (input, enablePrefix, prefix) {
   let str = ''
   let args = Object.values(input)
 
-  // Logic to check if first arg is a prefix
+  // logic to check if first arg is a prefix
   if (enablePrefix && typeof args[0] === 'string' && args.length > 1) {
-    // Custom prefix
+    // custom prefix
     str += args[0] + '  '
   } else if (enablePrefix && prefix && prefix.length > 0) {
-    // Defualt prefix
+    // defualt prefix
     let arg0 = (typeof args[0] === 'string') ? args[0] : util.inspect(args[0], false, null, false)
     str += prefix + '  ' + arg0
   } else if (args.length === 1) {
-    // No prefix
+    // no prefix
     let arg0 = (typeof args[0] === 'string') ? args[0] : util.inspect(args[0], false, null, false)
     str += arg0 + ' '
   }
 
-  // Print out remaining args
+  // print out remaining args
   let rest = args.slice(1)
   for (let k in rest) {
     let arg = (typeof rest[k] === 'string') ? rest[k] : util.inspect(rest[k], false, null, false)
@@ -61,199 +190,169 @@ function argumentsToString (input, enablePrefix, prefix) {
 
 /**
  * Generate params object based on params in logger constructor and defaults
- * @param {object} params - params in logger constructor
- * @returns {object} - fleshed out params object
- */
+ * @param {object} params - Params in logger constructor
+ * @returns {object} - Fleshed out params object
+  */
 function setParams (params) {
-  let newParams = {}
-  // loop params and assign values
-  for (let key in params) {
-    if (defaults[key]) {
-      // Setting up newParams[key] for a property in defaults.json
-      if (key === 'enablePrefix') {
-        newParams[key] = typeof params[key] === 'boolean' ? params[key] : defaults[key]
-      } else if (key === 'disable') {
-        newParams[key] = Array.isArray(params[key]) ? params[key] : defaults[key]
-      } else if (typeof params[key] === 'object') {
-        let { type, enable, prefix, color } = params[key]
-        newParams[key] = {
-          type: validateType(type) ? type : defaults[key].type,
-          enable: validateEnable(enable) ? enable : defaults[key].enable,
-          prefix: validatePrefix(prefix) ? prefix : defaults[key].prefix,
-          color: validateColor(color) ? color : defaults[key].color
-        }
-      } else if (typeof params[key] === 'boolean') {
-        newParams[key] = {
-          type: defaults[key].type,
-          enable: params[key],
-          prefix: defaults[key].prefix,
-          color: false
-        }
-      }
-    } else {
-      // Setting up newParams[key] for a custom property
-      if (typeof params[key] === 'object') {
-        let { type, enable, prefix, color } = params[key]
-        newParams[key] = {
-          type: validateType(type) ? type : 'info',
-          enable: validateEnable(enable) ? enable : true,
-          prefix: validatePrefix(prefix) ? prefix : undefined,
-          color: validateColor(color) ? color : undefined
-        }
-      } else if (typeof params[key] === 'boolean') {
-        newParams[key] = {
-          type: 'info',
-          enable: params[key],
-          prefix: undefined,
-          color: undefined
-        }
-      }
-    }
+  // sanitized configuration to output
+  const newParams = {
+    methods: {},
+    params: {}
   }
 
+  let globals = params.params || {}
+  let methods = params.methods || {}
+
+  // sanitize enablePrefix param
+  if (globals.hasOwnProperty('enablePrefix')) {
+    newParams.params.enablePrefix = typeof globals.enablePrefix === 'boolean' ? globals.enablePrefix : defaults.params.enablePrefix
+  } else {
+    newParams.params.enablePrefix = defaults.params.enablePrefix
+  }
+
+  // disable prefix via node env
   if (process.env['ROOSEVELT_LOGGER_ENABLE_PREFIX'] === 'false') {
-    newParams.enablePrefix = false
+    newParams.params.enablePrefix = false
+  }
+
+  // sanitize disable param
+  if (globals.hasOwnProperty('disable')) {
+    newParams.params.disable = Array.isArray(globals.disable) ? globals.disable : defaults.params.disable
+  } else {
+    newParams.params.disable = defaults.params.disable
+  }
+
+  // loop through and validate configured methods
+  for (let key in methods) {
+    // this if statement ensures that the method object doesn't get polluted by invalid params
+    if (validateLoggerMethod(key, methods[key])) {
+      newParams.methods[key] = validateLoggerMethod(key, methods[key])
+    }
   }
 
   // loop defaults to make sure the newParams contains all default log types
-  for (let key in defaults) {
-    if (newParams[key] === undefined) {
-      newParams[key] = defaults[key]
+  for (let key in defaults.methods) {
+    if (newParams.methods[key] === undefined) {
+      newParams.methods[key] = defaults.methods[key]
     }
   }
+
   return newParams
 }
 
-function Logger (params) {
-  this.params = setParams(params)
-  params = this.params
+/**
+ * Sanitize logger method configuration and return it
+ * @param {object} method - Logger method name
+ * @param {object|boolean} - Logger method config
+ * @returns {object} - Validated logger method config
+ */
+function validateLoggerMethod (method, params) {
+  let sanitizedConfig
 
-  // iterate over params
-  for (let key in params) {
-    // check if the param is already a key in the defaults
-    if (key in defaults) {
-      // set the value for the default param
-      if (key === 'disable') {
-        // loop through array of args in the disable param
-        for (let env in params[key]) {
-          // if the arg is set to true/"true" in process.env or it's the env in process.env.NODE_ENV, supress the logs
-          if (process.env.NODE_ENV === params[key][env] || process.env[params[key][env]] === 'true') {
-            transports.console.silent = true
-          }
-        }
-      }
-
-      if (['info', 'warn', 'verbose', 'error'].includes(key)) {
-        let { enablePrefix } = params
-        let { enable, type, color } = params[key]
-
-        this[key] = function (...args) {
-          createLog(args, enable, enablePrefix, params[key].prefix, color, type)
-        }
-      }
-    } else {
-      // the param is a new key that's not one of the defaults, assign values
-      let enable = params[key].enable
-      let type = params[key].type
-      let { enablePrefix } = params
-      let prefix = (typeof params[key].prefix === 'undefined')
-        ? (() => {
-          switch (type) {
-            case 'warn':
-              return '⚠️ '
-            case 'error':
-              return '❌'
-            default:
-              return false
-          }
-        })()
-        : params[key].prefix
-
-      let color = (typeof params[key].color === 'undefined')
-        ? (() => {
-          switch (type) {
-            case 'warn':
-              return 'yellow'
-            case 'error':
-              return 'red'
-            default:
-              return false
-          }
-        })()
-        : params[key].color
-
-      // create a function for the new param
-      this[key] = function (...args) {
-        createLog(args, enable, enablePrefix, prefix, color, type)
-      }
+  if (defaults.methods[method]) {
+    // sanitize the params on a default method
+    if (typeof params === 'object') {
+      let { type, enable, prefix, color } = params
+      sanitizedConfig = {}
+      sanitizedConfig.type = validateType(type) ? type : defaults.methods[method].type
+      sanitizedConfig.enable = validateEnable(enable) ? enable : defaults.methods[method].enable
+      sanitizedConfig.prefix = sanitizePrefix(prefix, sanitizedConfig.type)
+      sanitizedConfig.color = sanitizeColor(color, sanitizedConfig.type)
+    } else if (typeof params === 'boolean') {
+      sanitizedConfig = {}
+      sanitizedConfig.type = defaults.methods[method].type
+      sanitizedConfig.enable = params
+      sanitizedConfig.prefix = sanitizePrefix(defaults.methods[method].prefix, sanitizedConfig.type)
+      sanitizedConfig.color = sanitizeColor(defaults.methods[method].color, sanitizedConfig.type)
+    }
+  } else {
+    // sanitize the params on a custom method
+    if (typeof params === 'object') {
+      let { type, enable, prefix, color } = params
+      sanitizedConfig = {}
+      sanitizedConfig.type = validateType(type) ? type : 'info'
+      sanitizedConfig.enable = validateEnable(enable) ? enable : true
+      sanitizedConfig.prefix = sanitizePrefix(prefix, sanitizedConfig.type)
+      sanitizedConfig.color = sanitizeColor(color, sanitizedConfig.type)
+    } else if (typeof params === 'boolean') {
+      let { prefix, color } = params
+      sanitizedConfig = {}
+      sanitizedConfig.type = 'info'
+      sanitizedConfig.enable = params
+      sanitizedConfig.prefix = sanitizePrefix(prefix, sanitizedConfig.type)
+      sanitizedConfig.color = sanitizeColor(color, sanitizedConfig.type)
     }
   }
 
-  // create log function to map to logger.info
-  this.log = this.info
+  return sanitizedConfig
 }
 
 /**
- * Check the 'type' property is defined and a string
- * @param {string} type - type of a log type
+ * Check the 'type' property is defined and a valid option
+ * @param {string} type - Type of a log type
  */
 function validateType (type) {
-  return type !== undefined && typeof type === 'string'
+  return type !== undefined && ['info', 'warn', 'error'].includes(type)
 }
 
 /**
  * Check the 'enable' property is defined and a boolean
- * @param {boolean} enableBool - boolean to decide if a specific log type is enabled
+ * @param {boolean} enableBool - Boolean to decide if a specific log type is enabled
  */
 function validateEnable (enableBool) {
   return enableBool !== undefined && typeof enableBool === 'boolean'
 }
 
 /**
- * Check the 'prefix' property is defined and a string or boolean
- * @param {string|boolean} prefix - prefix of a log type
+ * Check the 'prefix' property is defined and a string or boolean and set to a default if undefined
+ * @param {string|boolean} prefix - Prefix of a log type
+ * @param {string} type - Type of a log type
  */
-function validatePrefix (prefix) {
-  return prefix !== undefined && (typeof prefix === 'string' || typeof prefix === 'boolean')
-}
+function sanitizePrefix (prefix, type) {
+  // sanitize prefix
+  let validPrefix = prefix !== undefined && (typeof prefix === 'string' || typeof prefix === 'boolean')
 
-/**
- * Check the 'color' property is defined and a string or boolean
- * @param {string|boolean} color - custom color of a log type
- */
-function validateColor (color) {
-  return color !== undefined && (typeof color === 'string' || typeof color === 'boolean')
-}
-
-/**
- * Parse send a log to the logger
- * @param {Array<*>} args - args to pass to the interal logger
- * @param {boolean} enable - flag to state if this should be logged
- * @param {boolean} enablePrefix - flag to state if the prefix should be printed
- * @param {string} prefix - the prefix for this log entry
- * @param {string} color - the color for this log entry
- * @param {string} type - the internal log level type for winston
- */
-function createLog (args, enable, enablePrefix, prefix, color, type) {
-  // log if the param is set to true
-  if (enable !== 'false' && enable !== false) {
-    // parse the log arguments
-    let logs = argumentsToString(args, enablePrefix, prefix)
-    // send the log level and message to winston for logging
-    if (color === false) {
-      wLogger.log({ level: type, message: logs })
-    } else {
-      wLogger.log({ level: type, message: colors[color](logs) })
+  // set to a default if invalid
+  if (!validPrefix) {
+    switch (type) {
+      case 'warn':
+        prefix = '⚠️ '
+        break
+      case 'error':
+        prefix = '❌'
+        break
+      default:
+        prefix = false
     }
   }
+
+  return prefix
 }
 
-module.exports = createLogger
+/**
+ * Check the 'color' property is defined and a string or boolean and set to a default if undefined
+ * @param {string|boolean} color - Custom color of a log type
+ * @param {string} type - Type of a log type
+ */
+function sanitizeColor (color, type) {
+  // check color validity
+  let validColor = color !== undefined && (typeof color === 'string' || typeof color === 'boolean')
 
-function createLogger (params) {
-  return new Logger(params)
+  // set to a default if invalid
+  if (!validColor) {
+    switch (type) {
+      case 'warn':
+        color = 'yellow'
+        break
+      case 'error':
+        color = 'red'
+        break
+      default:
+        color = false
+    }
+  }
+
+  return color
 }
 
-createLogger.winston = winston
-createLogger.winstonInstance = wLogger
-createLogger.transports = transports
+module.exports = Logger

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -4,53 +4,58 @@ const assert = require('assert')
 const { fork } = require('child_process')
 const path = require('path')
 const util = require('util')
+const Logger = require('../../logger')
 
 describe('Logger Tests', function () {
   // Parameters to pass to the logger
   let configs = {
-    'info': 'badparam',
-    'warn': true,
-    'verbose': {
-      'type': 'info',
-      'enable': true,
-      'prefix': false,
-      'color': false
+    methods: {
+      'info': 'badparam',
+      'warn': true,
+      'verbose': {
+        'type': 'info',
+        'enable': true,
+        'prefix': false,
+        'color': false
+      },
+      'error': {
+        'type': undefined,
+        'enable': undefined,
+        'prefix': undefined,
+        'color': undefined
+      },
+      'custom1': true,
+      'custom2': {
+        'type': 'info',
+        'prefix': true,
+        'color': false
+      },
+      'custom3': {
+        'enable': true
+      },
+      'custom4': {
+        'enable': true,
+        'type': 'error'
+      },
+      'custom5': {
+        'enable': false
+      },
+      'custom6': {
+        'type': 'warn'
+      },
+      'custom7': {
+        'type': 'info',
+        'prefix': '🍕',
+        'enable': true,
+        'color': false
+      },
+      'custom8': false,
+      'custom9': 'badvalue'
     },
-    'error': {
-      'type': undefined,
-      'enable': undefined,
-      'prefix': undefined,
-      'color': undefined
-    },
-    'enablePrefix': 'default',
-    'custom1': true,
-    'custom2': {
-      'type': 'info',
-      'prefix': true,
-      'color': false
-    },
-    'custom3': {
-      'enable': true
-    },
-    'custom4': {
-      'enable': true,
-      'type': 'error'
-    },
-    'custom5': {
-      'enable': false
-    },
-    'custom6': {
-      'type': 'warn'
-    },
-    'custom7': {
-      'type': 'info',
-      'prefix': '🍕',
-      'enable': true,
-      'color': false
-    },
-    'custom8': false,
-    'custom9': 'badvalue',
-    'disable': null
+    params: {
+      'enablePrefix': 'default',
+      'disable': null
+    }
   }
 
   // hook for stdout and stderr streams
@@ -67,8 +72,8 @@ describe('Logger Tests', function () {
   }
 
   it('should initialize a logger and test many different logs', function (done) {
-    // require the logger for this test
-    const logger = require('../../logger')(configs)
+    // instantiate the logger for this test
+    const logger = new Logger(configs)
 
     // variable to store the logs
     let logs = []
@@ -135,8 +140,8 @@ describe('Logger Tests', function () {
   })
 
   it('should use the defaults if no logging params are passed in', function (done) {
-    // require the logger for this test
-    const logger = require('../../logger')()
+    // instantiate the logger for this test
+    const logger = new Logger()
 
     // variable to store the logs
     let logs = []
@@ -175,8 +180,8 @@ describe('Logger Tests', function () {
   })
 
   it('should handle empty logs and other data types', function (done) {
-    // require the logger for this test
-    const logger = require('../../logger')()
+    // instantiate the logger for this test
+    const logger = new Logger()
 
     // variable to store the logs
     let logs = []
@@ -208,9 +213,9 @@ describe('Logger Tests', function () {
   })
 
   it('Should remove prefixes when enablePrefix is set to false', function (done) {
-    // require the logger for this test
+    // instantiate the logger for this test
     configs.enablePrefix = false
-    const logger = require('../../logger')(configs)
+    const logger = new Logger(configs)
 
     // variable to store the logs
     let logs = []
@@ -312,5 +317,115 @@ describe('Logger Tests', function () {
     forkedLogger.on('exit', () => {
       done()
     })
+  })
+
+  it('Should disable logs via logger.disableLogging method and enable logs via logger.enableLogging method', function (done) {
+    // instantiate the logger for this test
+    const logger = new Logger()
+
+    // variable to store the logs
+    let logs = []
+    // hook up standard output
+    let unhookStdout = hookStream(process.stdout, function (string, encoding, fd) {
+      logs.push(string)
+    })
+
+    // disable logging
+    logger.disableLogging()
+
+    // testing log
+    logger.log('This log should not be seen')
+
+    // re-enable logging
+    logger.enableLogging()
+
+    // testing log
+    logger.log('This log should be seen')
+
+    // unhook stdout
+    unhookStdout()
+
+    // log assertions
+    assert.strictEqual(logs.length === 1, true, 'The logger failed to disable logging')
+    assert.strictEqual(logs[0].includes('This log should be seen'), true, 'The logger failed to enable logging')
+
+    // exit test
+    done()
+  })
+
+  it('Should disable prefix via logger.disablePrefix method and enable prefix via logger.enablePrefix method', function (done) {
+    // instantiate the logger for this test
+    const logger = new Logger()
+
+    // variable to store the logs
+    let errors = []
+    // hook up standard output
+    let unhookStderr = hookStream(process.stderr, function (string, encoding, fd) {
+      errors.push(string)
+    })
+
+    // disable prefix
+    logger.disablePrefix()
+
+    // testing log
+    logger.warn('This prefix should not be seen')
+
+    // re-enable prefix
+    logger.enablePrefix()
+
+    // testing log
+    logger.warn('This prefix should be seen')
+
+    // unhook stdout
+    unhookStderr()
+
+    // log assertions
+    assert.strictEqual(errors[0].includes('This prefix should not be seen'), true, 'The logger failed to disable the prefix')
+    assert.strictEqual(errors[1].includes('⚠️   This prefix should be seen'), true, 'The logger failed to enable the prefix')
+
+    // exit test
+    done()
+  })
+
+  it('Should create a new functional log type via logger.createLogMethod method', function (done) {
+    // instantiate the logger for this test
+    const logger = new Logger()
+
+    // variable to store the logs
+    let logs = []
+    let errors = []
+
+    // hook up standard output/errors
+    let unhookStdout = hookStream(process.stdout, function (string, encoding, fd) {
+      logs.push(string)
+    })
+    let unhookStderr = hookStream(process.stderr, function (string, encoding, fd) {
+      errors.push(string)
+    })
+
+    // programmatically generate a new log type
+    logger.createLogMethod({
+      name: 'test',
+      type: 'info'
+    })
+
+    // test out the new log type
+    logger.test('This is a test')
+
+    // generate another new invalid log type
+    logger.createLogMethod({
+      type: 'info'
+    })
+
+    // unhook stdout
+    unhookStdout()
+    unhookStderr()
+
+    // log assertions
+    assert.strictEqual(logs[0].includes('This is a test'), true, 'The logger failed to log with the new log type')
+    assert.strictEqual(errors[0].includes('Must be type string.'), true, 'The logger attempted to create invalid log type')
+
+    // exit test
+    done()
   })
 })

--- a/test/util/fork.js
+++ b/test/util/fork.js
@@ -1,4 +1,4 @@
-// Require logger
+// require logger
 const Logger = require('../../logger')
 const logger = new Logger({
   params: {
@@ -7,6 +7,6 @@ const logger = new Logger({
   }
 })
 
-// Output a test log with and without a prefix
+// output a test log with and without a prefix
 logger.log('Test Log')
 logger.warn('Test Warning Log')

--- a/test/util/fork.js
+++ b/test/util/fork.js
@@ -1,5 +1,11 @@
 // Require logger
-const logger = require('../../logger')({ disable: ['production', 'test1', 'test2'] })
+const Logger = require('../../logger')
+const logger = new Logger({
+  params: {
+    enablePrefix: true,
+    disable: ['production', 'test1', 'test2']
+  }
+})
 
 // Output a test log with and without a prefix
 logger.log('Test Log')

--- a/test/util/windowsFork.js
+++ b/test/util/windowsFork.js
@@ -1,0 +1,35 @@
+const Logger = require('../../logger')
+
+// spoof windows environment
+Object.defineProperty(process, 'platform', {
+  value: 'win32'
+})
+
+// instantiate logger
+let logger = new Logger({
+  params: {
+    enablePrefix: true
+  }
+})
+
+// output a test log that would normally include a prefix
+logger.warn('No prefix')
+
+// force enable prefix
+logger.enablePrefix()
+
+// this log should have a prefix
+logger.warn('A prefix enabled programmatically')
+
+// set env that would enable prefix
+process.env.ROOSEVELT_LOGGER_ENABLE_PREFIX = 'true'
+
+// spin up a new logger instance
+logger = new Logger({
+  params: {
+    enablePrefix: true
+  }
+})
+
+// a prefix should show thanks to the env
+logger.warn('A prefix enabled via env')


### PR DESCRIPTION
- Rewrote export into a proper ES2015 class.
- Added an assortment of class methods to interact with the logger programmatically:
  - `.enableLogger()` and `.disableLogger()` to turn logs on/off.
  - `.enablePrefix()` and `disablePrefix()` to turn prefixes on/off.
  - `.createLogMethod()` to programmatically add a new custom logger method.
- API Changes:
  - `methods` object containing each configured logger method.
  - `params` object containing the global logger params.

closes https://github.com/rooseveltframework/roosevelt-logger/issues/37
closes https://github.com/rooseveltframework/roosevelt-logger/issues/34