### PR TITLE
fix: fixed incorrect numbering in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Put your changes here...
 
-## 0.2.3
+## 0.2.2
 
 - Fixed bug which caused whitespace at the end of a log to be removed.
 - Better docs.


### PR DESCRIPTION
The newest version of the logger is 0.2.2, not 0.2.3 so I went and fixed this in the changelog.